### PR TITLE
use new modbus event prototypes for Zeek v6.1.0+

### DIFF
--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -757,10 +757,16 @@ event modbus_read_write_multiple_registers_response(c: connection,
 #############################################################################################################################
 #####################  Defines logging of modbus_read_file_record_request event -> modbus_detailed.log  #####################
 #############################################################################################################################
+@if (Version::at_least("6.1.0"))
 event modbus_read_file_record_request(c: connection,
                                       headers: ModbusHeaders,
                                       byte_count: count,
-                                      refs: ModbusFileRecordRequests) {
+                                      refs: ModbusFileRecordRequests)
+@else
+event modbus_read_file_record_request(c: connection,
+                                      headers: ModbusHeaders)
+@endif
+{
 
     local read_file_record_request: Modbus_Detailed;
 
@@ -784,10 +790,16 @@ event modbus_read_file_record_request(c: connection,
 #############################################################################################################################
 ####################  Defines logging of modbus_read_file_record_response event -> modbus_detailed.log  #####################
 #############################################################################################################################
+@if (Version::at_least("6.1.0"))
 event modbus_read_file_record_response(c: connection,
                                        headers: ModbusHeaders,
                                        byte_count: count,
-                                       refs: ModbusFileRecordResponses) {
+                                       refs: ModbusFileRecordResponses)
+@else
+event modbus_read_file_record_response(c: connection,
+                                       headers: ModbusHeaders)
+@endif
+{
 
     local read_file_record_response: Modbus_Detailed; 
 
@@ -811,10 +823,16 @@ event modbus_read_file_record_response(c: connection,
 #############################################################################################################################
 ####################  Defines logging of modbus_write_file_record_request event -> modbus_detailed.log  #####################
 #############################################################################################################################
+@if (Version::at_least("6.1.0"))
 event modbus_write_file_record_request(c: connection,
                                        headers: ModbusHeaders,
                                        byte_count: count,
-                                       refs: ModbusFileReferences) {
+                                       refs: ModbusFileReferences)
+@else
+event modbus_write_file_record_request(c: connection,
+                                       headers: ModbusHeaders)
+@endif
+{
 
     local write_file_record_request: Modbus_Detailed;
 
@@ -838,10 +856,16 @@ event modbus_write_file_record_request(c: connection,
 #############################################################################################################################
 ###################  Defines logging of modbus_write_file_record_response event -> modbus_detailed.log  #####################
 #############################################################################################################################
+@if (Version::at_least("6.1.0"))
 event modbus_write_file_record_response(c: connection,
                                         headers: ModbusHeaders,
                                         byte_count: count,
-                                        refs: ModbusFileReferences) {
+                                        refs: ModbusFileReferences)
+@else
+event modbus_write_file_record_response(c: connection,
+                                        headers: ModbusHeaders)
+@endif
+{
 
     local write_file_record_response: Modbus_Detailed;
 

--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -757,8 +757,10 @@ event modbus_read_write_multiple_registers_response(c: connection,
 #############################################################################################################################
 #####################  Defines logging of modbus_read_file_record_request event -> modbus_detailed.log  #####################
 #############################################################################################################################
-event modbus_read_file_record_request(c: connection, 
-                                      headers: ModbusHeaders) {
+event modbus_read_file_record_request(c: connection,
+                                      headers: ModbusHeaders,
+                                      byte_count: count,
+                                      refs: ModbusFileRecordRequests) {
 
     local read_file_record_request: Modbus_Detailed;
 
@@ -782,8 +784,10 @@ event modbus_read_file_record_request(c: connection,
 #############################################################################################################################
 ####################  Defines logging of modbus_read_file_record_response event -> modbus_detailed.log  #####################
 #############################################################################################################################
-event modbus_read_file_record_response(c: connection, 
-                                       headers: ModbusHeaders) {  
+event modbus_read_file_record_response(c: connection,
+                                       headers: ModbusHeaders,
+                                       byte_count: count,
+                                       refs: ModbusFileRecordResponses) {
 
     local read_file_record_response: Modbus_Detailed; 
 
@@ -807,8 +811,10 @@ event modbus_read_file_record_response(c: connection,
 #############################################################################################################################
 ####################  Defines logging of modbus_write_file_record_request event -> modbus_detailed.log  #####################
 #############################################################################################################################
-event modbus_write_file_record_request(c: connection, 
-                                       headers: ModbusHeaders){  
+event modbus_write_file_record_request(c: connection,
+                                       headers: ModbusHeaders,
+                                       byte_count: count,
+                                       refs: ModbusFileReferences) {
 
     local write_file_record_request: Modbus_Detailed;
 
@@ -832,8 +838,10 @@ event modbus_write_file_record_request(c: connection,
 #############################################################################################################################
 ###################  Defines logging of modbus_write_file_record_response event -> modbus_detailed.log  #####################
 #############################################################################################################################
-event modbus_write_file_record_response(c: connection, 
-                                        headers: ModbusHeaders) {
+event modbus_write_file_record_response(c: connection,
+                                        headers: ModbusHeaders,
+                                        byte_count: count,
+                                        refs: ModbusFileReferences) {
 
     local write_file_record_response: Modbus_Detailed;
 


### PR DESCRIPTION
The [Zeek v6.1.0](https://github.com/zeek/zeek/releases/tag/v6.1.0) release states:

```
The ModBus file record read and write events now provide the full data from
the request and response messages as part of the event data.

The full PDU length was added to the ModBusHeader record type passed with
all of the ModBus events.
```

This commit handles the deprecated function warnings:

```
warning in /opt/zeek/share/zeek/site/packages/icsnpp-modbus/main.zeek, line 761 and /opt/zeek/share/zeek/base/bif/plugins/Zeek_Modbus.events.bif.zeek, line 220: use of deprecated 'modbus_read_file_record_request' prototype: Remove in v7.1. Use the version that takes a byte_count and vector of references (event(c:connection, headers:ModbusHeaders))
warning in /opt/zeek/share/zeek/site/packages/icsnpp-modbus/main.zeek, line 786 and /opt/zeek/share/zeek/base/bif/plugins/Zeek_Modbus.events.bif.zeek, line 234: use of deprecated 'modbus_read_file_record_response' prototype: Remove in v7.1. Use the version that takes a byte_count and vector of references (event(c:connection, headers:ModbusHeaders))
warning in /opt/zeek/share/zeek/site/packages/icsnpp-modbus/main.zeek, line 811 and /opt/zeek/share/zeek/base/bif/plugins/Zeek_Modbus.events.bif.zeek, line 248: use of deprecated 'modbus_write_file_record_request' prototype: Remove in v7.1. Use the version that takes a byte_count and vector of references (event(c:connection, headers:ModbusHeaders))
warning in /opt/zeek/share/zeek/site/packages/icsnpp-modbus/main.zeek, line 836 and /opt/zeek/share/zeek/base/bif/plugins/Zeek_Modbus.events.bif.zeek, line 262: use of deprecated 'modbus_write_file_record_response' prototype: Remove in v7.1. Use the version that takes a byte_count and vector of references (event(c:connection, headers:ModbusHeaders))
```