### PR TITLE
Align comment style with zeek comment style so docs generation works

### DIFF
--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -22,21 +22,21 @@ export {
     #####################################  Modbus Detailed Log -> modbus_detailed.log  ######################################
     #########################################################################################################################
     type Modbus_Detailed: record {
-        ts                      : time              &log;             # Timestamp of event
-        uid                     : string            &log;             # Zeek unique ID for connection
-        id                      : conn_id           &log;             # Zeek connection struct (addresses and ports)
-        is_orig                 : bool              &log;             # the message came from the originator/client or the responder/server
-        source_h                : addr              &log;             # Source IP Address
-        source_p                : port              &log;             # Source Port
-        destination_h           : addr              &log;             # Destination IP Address
-        destination_p           : port              &log;             # Destination Port
-        tid                     : count             &log &optional;   # Modbus transaction id
-        unit                    : count             &log &optional;   # Modbus terminal unit identifier
-        func                    : string            &log &optional;   # Modbus Function
-        request_response        : string            &log &optional;   # REQUEST or RESPONSE
-        address                 : count             &log &optional;   # Starting address for value(s) field
-        quantity                : count             &log &optional;   # Number of addresses/values read or written to
-        values                  : string            &log &optional;   # Coils, discrete_inputs, or registers read/written to
+        ts                      : time              &log;             ##< Timestamp of event
+        uid                     : string            &log;             ##< Zeek unique ID for connection
+        id                      : conn_id           &log;             ##< Zeek connection struct (addresses and ports)
+        is_orig                 : bool              &log;             ##< the message came from the originator/client or the responder/server
+        source_h                : addr              &log;             ##< Source IP Address
+        source_p                : port              &log;             ##< Source Port
+        destination_h           : addr              &log;             ##< Destination IP Address
+        destination_p           : port              &log;             ##< Destination Port
+        tid                     : count             &log &optional;   ##< Modbus transaction id
+        unit                    : count             &log &optional;   ##< Modbus terminal unit identifier
+        func                    : string            &log &optional;   ##< Modbus Function
+        request_response        : string            &log &optional;   ##< REQUEST or RESPONSE
+        address                 : count             &log &optional;   ##< Starting address for value(s) field
+        quantity                : count             &log &optional;   ##< Number of addresses/values read or written to
+        values                  : string            &log &optional;   ##< Coils, discrete_inputs, or registers read/written to
     };
     global log_modbus_detailed: event(rec: Modbus_Detailed);
 
@@ -44,21 +44,21 @@ export {
     #############################  Mask Write Register Log -> modbus_mask_write_register.log  ###############################
     #########################################################################################################################
     type Mask_Write_Register: record {
-        ts                      : time              &log;             # Timestamp of event
-        uid                     : string            &log;             # Zeek unique ID for connection
-        id                      : conn_id           &log;             # Zeek connection struct (addresses and ports)
-        is_orig                 : bool              &log;             # the message came from the originator/client or the responder/server
-        source_h                : addr              &log;             # Source IP Address
-        source_p                : port              &log;             # Source Port
-        destination_h           : addr              &log;             # Destination IP Address
-        destination_p           : port              &log;             # Destination Port
-        tid                     : count             &log &optional;   # Modbus transaction id
-        unit                    : count             &log &optional;   # Modbus terminal unit identifier
-        func                    : string            &log &optional;   # Modbus Function
-        request_response        : string            &log &optional;   # REQUEST or RESPONSE
-        address                 : count             &log &optional;   # Address of the target register
-        and_mask                : count             &log &optional;   # Boolean 'and' mask to apply to the target register
-        or_mask                 : count             &log &optional;   # Boolean 'or' mask to apply to the target register
+        ts                      : time              &log;             ##< Timestamp of event
+        uid                     : string            &log;             ##< Zeek unique ID for connection
+        id                      : conn_id           &log;             ##< Zeek connection struct (addresses and ports)
+        is_orig                 : bool              &log;             ##< the message came from the originator/client or the responder/server
+        source_h                : addr              &log;             ##< Source IP Address
+        source_p                : port              &log;             ##< Source Port
+        destination_h           : addr              &log;             ##< Destination IP Address
+        destination_p           : port              &log;             ##< Destination Port
+        tid                     : count             &log &optional;   ##< Modbus transaction id
+        unit                    : count             &log &optional;   ##< Modbus terminal unit identifier
+        func                    : string            &log &optional;   ##< Modbus Function
+        request_response        : string            &log &optional;   ##< REQUEST or RESPONSE
+        address                 : count             &log &optional;   ##< Address of the target register
+        and_mask                : count             &log &optional;   ##< Boolean 'and' mask to apply to the target register
+        or_mask                 : count             &log &optional;   ##< Boolean 'or' mask to apply to the target register
     };
     global log_mask_write_register: event(rec: Mask_Write_Register);
 
@@ -66,23 +66,23 @@ export {
     ###################  Read Write Multiple Registers Log -> modbus_read_write_multiple_registers.log  #####################
     #########################################################################################################################
     type Read_Write_Multiple_Registers: record {
-        ts                      : time              &log;             # Timestamp of event
-        uid                     : string            &log;             # Zeek unique ID for connection
-        id                      : conn_id           &log;             # Zeek connection struct (addresses and ports)
-        is_orig                 : bool              &log;             # the message came from the originator/client or the responder/server
-        source_h                : addr              &log;             # Source IP Address
-        source_p                : port              &log;             # Source Port
-        destination_h           : addr              &log;             # Destination IP Address
-        destination_p           : port              &log;             # Destination Port
-        tid                     : count             &log &optional;   # Modbus transaction id
-        unit                    : count             &log &optional;   # Modbus terminal unit identifier
-        func                    : string            &log &optional;   # Modbus Function
-        request_response        : string            &log &optional;   # REQUEST or RESPONSE
-        write_start_address     : count             &log &optional;   # Starting address of the registers to write to
-        write_registers         : ModbusRegisters   &log &optional;   # Register values written
-        read_start_address      : count             &log &optional;   # Starting address of the registers to read
-        read_quantity           : count             &log &optional;   # Number of registers to read
-        read_registers          : ModbusRegisters   &log &optional;   # Register values read
+        ts                      : time              &log;             ##< Timestamp of event
+        uid                     : string            &log;             ##< Zeek unique ID for connection
+        id                      : conn_id           &log;             ##< Zeek connection struct (addresses and ports)
+        is_orig                 : bool              &log;             ##< the message came from the originator/client or the responder/server
+        source_h                : addr              &log;             ##< Source IP Address
+        source_p                : port              &log;             ##< Source Port
+        destination_h           : addr              &log;             ##< Destination IP Address
+        destination_p           : port              &log;             ##< Destination Port
+        tid                     : count             &log &optional;   ##< Modbus transaction id
+        unit                    : count             &log &optional;   ##< Modbus terminal unit identifier
+        func                    : string            &log &optional;   ##< Modbus Function
+        request_response        : string            &log &optional;   ##< REQUEST or RESPONSE
+        write_start_address     : count             &log &optional;   ##< Starting address of the registers to write to
+        write_registers         : ModbusRegisters   &log &optional;   ##< Register values written
+        read_start_address      : count             &log &optional;   ##< Starting address of the registers to read
+        read_quantity           : count             &log &optional;   ##< Number of registers to read
+        read_registers          : ModbusRegisters   &log &optional;   ##< Register values read
     };
     global log_read_write_multiple_registers: event(rec: Read_Write_Multiple_Registers);
 
@@ -90,25 +90,25 @@ export {
     #######################  Read Device Identification Log -> modbus_read_device_identification.log  #######################
     #########################################################################################################################
     type Read_Device_Identification: record {
-        ts                      : time              &log;             # Timestamp of event
-        uid                     : string            &log;             # Zeek unique ID for connection
-        id                      : conn_id           &log;             # Zeek connection struct (addresses and ports)
-        is_orig                 : bool              &log;             # the message came from the originator/client or the responder/server
-        source_h                : addr              &log;             # Source IP Address
-        source_p                : port              &log;             # Source Port
-        destination_h           : addr              &log;             # Destination IP Address
-        destination_p           : port              &log;             # Destination Port
-        tid                     : count             &log &optional;   # Modbus transaction id
-        unit                    : count             &log &optional;   # Modbus terminal unit identifier
-        func                    : string            &log &optional;   # Modbus Function - 
-        request_response        : string            &log &optional;   # REQUEST or RESPONSE
-        mei_type                : string            &log &optional;   # MEI Type - Always READ-DEVICE-IDENTIFICATION
-        conformity_level_code   : string            &log &optional;   # Conformity Level Code
-        conformity_level        : string            &log &optional;   # Conformity Level 
-        device_id_code          : count             &log &optional;   # Device ID Code
-        object_id_code          : string            &log &optional;   # Object ID Code
-        object_id               : string            &log &optional;   # Object ID
-        object_value            : string            &log &optional;   # Object Value
+        ts                      : time              &log;             ##< Timestamp of event
+        uid                     : string            &log;             ##< Zeek unique ID for connection
+        id                      : conn_id           &log;             ##< Zeek connection struct (addresses and ports)
+        is_orig                 : bool              &log;             ##< the message came from the originator/client or the responder/server
+        source_h                : addr              &log;             ##< Source IP Address
+        source_p                : port              &log;             ##< Source Port
+        destination_h           : addr              &log;             ##< Destination IP Address
+        destination_p           : port              &log;             ##< Destination Port
+        tid                     : count             &log &optional;   ##< Modbus transaction id
+        unit                    : count             &log &optional;   ##< Modbus terminal unit identifier
+        func                    : string            &log &optional;   ##< Modbus Function - 
+        request_response        : string            &log &optional;   ##< REQUEST or RESPONSE
+        mei_type                : string            &log &optional;   ##< MEI Type - Always READ-DEVICE-IDENTIFICATION
+        conformity_level_code   : string            &log &optional;   ##< Conformity Level Code
+        conformity_level        : string            &log &optional;   ##< Conformity Level 
+        device_id_code          : count             &log &optional;   ##< Device ID Code
+        object_id_code          : string            &log &optional;   ##< Object ID Code
+        object_id               : string            &log &optional;   ##< Object ID
+        object_value            : string            &log &optional;   ##< Object Value
     };
     global log_read_device_identification: event(rec: Read_Device_Identification);
 }


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
When you do single line comments in Zeek, zeekygen expects ##< to signal where they apply, so changed single hases to those.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
fixes automated documentation and schema generation.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
its just changes to comments

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [ x] Changes are limited to a single goal - *eschew scope creep!*
- [ x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [ x] All relevant type-of-change labels have been added.
- [ x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ x] Tests have been added and/or modified to cover the changes in this PR.
- [ x] All new and existing tests pass.
- [ x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
