### PR TITLE
Added log policy hooks for Mobus_Extended records

### DIFF
--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -44,6 +44,7 @@ export {
     };
     global modbus_pending: table[string] of table[count] of Modbus_Detailed; 
     global log_modbus_detailed: event(rec: Modbus_Detailed);
+    global log_policy_modbus_detailed: Log::PolicyHook;
 
     #########################################################################################################################
     #############################  Mask Write Register Log -> modbus_mask_write_register.log  ###############################
@@ -67,6 +68,7 @@ export {
         or_mask                 : count             &log &optional;   ##< Boolean 'or' mask to apply to the target register
     };
     global log_mask_write_register: event(rec: Mask_Write_Register);
+    global log_policy_mask_write_register: Log::PolicyHook;
 
     #########################################################################################################################
     ###################  Read Write Multiple Registers Log -> modbus_read_write_multiple_registers.log  #####################
@@ -92,6 +94,7 @@ export {
         read_registers          : ModbusRegisters   &log &optional;   # Register values read
     };
     global log_read_write_multiple_registers: event(rec: Read_Write_Multiple_Registers);
+    global log_policy_read_write_multiple_registers: Log::PolicyHook;
 
     #########################################################################################################################
     #######################  Read Device Identification Log -> modbus_read_device_identification.log  #######################
@@ -119,6 +122,7 @@ export {
         object_value            : string            &log &optional;   ##< Object Value
     };
     global log_read_device_identification: event(rec: Read_Device_Identification);
+    global log_policy_read_device_identification: Log::PolicyHook;
 }
 
 global modbus_requests: table[conn_id] of table[count] of Modbus_Detailed; 
@@ -274,19 +278,23 @@ function handled_modbus_funct_list (cur_func_str : string): bool {
 event zeek_init() &priority=5 {
     Log::create_stream(Modbus_Extended::LOG_DETAILED, [$columns=Modbus_Detailed, 
                                                        $ev=log_modbus_detailed,
-                                                       $path="modbus_detailed"]);
+                                                       $path="modbus_detailed",
+                                                       $policy=log_policy_modbus_detailed]);
 
     Log::create_stream(Modbus_Extended::LOG_MASK_WRITE_REGISTER, [$columns=Mask_Write_Register,
                                                                   $ev=log_mask_write_register,
-                                                                  $path="modbus_mask_write_register"]);
+                                                                  $path="modbus_mask_write_register",
+                                                                  $policy=log_policy_mask_write_register]);
 
     Log::create_stream(Modbus_Extended::LOG_READ_WRITE_MULTIPLE_REGISTERS, [$columns=Read_Write_Multiple_Registers, 
                                                                             $ev=log_read_write_multiple_registers,
-                                                                            $path="modbus_read_write_multiple_registers"]);
+                                                                            $path="modbus_read_write_multiple_registers",
+                                                                            $policy=log_policy_read_write_multiple_registers]);
 
     Log::create_stream(Modbus_Extended::LOG_READ_DEVICE_IDENTIFICATION, [$columns=Read_Device_Identification, 
                                                                             $ev=log_read_device_identification,
-                                                                            $path="modbus_read_device_identification"]);
+                                                                            $path="modbus_read_device_identification",
+                                                                            $policy=log_policy_read_device_identification]);
 }
 
 #############################################################################################################################


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Added `Log::PolicyHook`s for each `Modbus_Extended` record:
- `log_policy_modbus_detailed` for `Modbus_Detailed`
- `log_policy_mask_write_register` for `Mask_Write_Register`
- `log_policy_read_write_multiple_registers` for `Read_Write_Multiple_Registers`
- `log_policy_read_device_identification` for `Read_Device_Identification`

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
`Log::PolicyHook` provides better control over log writes for those modifying the default logging behavior of a stream. For example, I needed to add an extra field to each `Modbus_Extended` record and assign the field a value before the record got logged.

Other ICSNPP Zeek packages by CISAGOV have log policy hooks for their module records, such as [cisagov/icsnpp-s7comm](https://github.com/cisagov/icsnpp-s7comm/blob/main/scripts/icsnpp/s7comm/main.zeek#L37) and [cisagov/icsnpp-enip](https://github.com/cisagov/icsnpp-enip/blob/main/scripts/icsnpp/enip/main.zeek#L42).

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
No tests were conducted nor created since these changes do not alter any default logging functionality.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document. **(NOTE: this file does not exist.)**
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
